### PR TITLE
feat: proxy POS to netlify

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,2 @@
+/*    /index.html   200
 /poss/*  https://possoft.netlify.app/:splat  200


### PR DESCRIPTION
This change adds a redirect rule to proxy requests from /poss to possoft.netlify.app.