### PR TITLE
feat: redirect POS to netlify

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,2 @@
+/poss/*  https://possoft.netlify.app/:splat  301!
 /*    /index.html   200
-/poss/*  https://possoft.netlify.app/:splat  200


### PR DESCRIPTION
This change adds a redirect rule to redirect requests from /poss to possoft.netlify.app.